### PR TITLE
Improve tasks to leverage Ansible modules, minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
 # Elastic APM Server Role
 
-Ansible role for downloading and configuring Elastic APM Server. This role creates the ```apm-server.yml```
-file with the default values defined.
+Ansible role for downloading and configuring [Elastic APM Server](https://www.elastic.co/solutions/apm).
+This role creates the `apm-server.yml` file with the default values defined.
 
-
-Role Variables
---------------
-#### Default installation values
+## Role Variables
+### Default installation values
 
 ```yaml
 apm_server_version: 6.4.0
 ```
 
-#### Configuration
+### Configuration
 
-The default values are already installed in the ```apm-server.yml``` file.
-If you need to define variables or overwrite any default, you should use the ```apm_server_conf_``` prefix, and replace
-dashes and dots by underscores as shown below:
+The default values are already installed in the `apm-server.yml` file.
+If you need to define variables or overwrite any default, you should use the
+`apm_server_conf_` prefix, and replace dashes and dots by underscores as shown below:
 
 ```yaml
 apm_server_conf_apm_server_host: localhost:8200
@@ -24,9 +22,8 @@ apm_server_conf_setup_template_settings_index_number_of_shards: 1
 apm_server_conf_setup_template_settings_index_codec: best_compression
 apm_server_conf_output_elasticsearch_hosts: ["localhost:9200"]
 apm_server_conf_logging_metrics_enabled: false
-``` 
+```
 
-License
--------
+## License
 
 GNU GPLv3

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: restart apm-server
   service:
     name: apm-server

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,21 +2,21 @@
 galaxy_info:
   author:
     - Guido Navalesi (@gnavalesi)
-  description: Downloads and configure Elastic APM Server
+  description: Download and configure Elastic APM Server
   license: GNU GPLv3
   min_ansible_version: 2
   platforms:
-  - name: Debian
-    versions:
-    - all
-  - name: Ubuntu
-    versions:
-    - all
+    - name: Debian
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all
   galaxy_tags:
-    - monitoring
+    - apm
+    - elk
+    - java
     - logging
     - metrics
-    - apm
-    - java
-    - elk
+    - monitoring
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,32 +1,36 @@
 ---
-
-- name: Add ElasticSearch apt key
-  shell: wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
-
-- name: Install APM Server pre-req software
+- name: Install prerequisites
   apt:
-    name: "{{ item }}"
-  with_items: "{{ apm_server_prereq }}"
+    name: "{{ apm_server_prereq }}"
+    state: present
 
-- name: Add Elastic apt repository.
+- name: Add the Elastic APT repository key
+  apt_key:
+    url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    state: present
+
+- name: Add the Elastic APT repository
   apt_repository:
     repo: "{{ apm_server_elastic_repo_url }}"
     state: present
 
-- name: Install APM Server package
+- name: Install APM Server
   apt:
     name: "apm-server={{ apm_server_version }}"
     state: present
 
-- name: Ensure APM Server is started and enabled on boot.
-  service:
-    name: "apm-server"
-    state: started
-    enabled: yes
-
-- name: Install apm-server.yml
+- name: Deploy service configuration
   template:
     src: apm-server.yml.j2
     dest: /etc/apm-server/apm-server.yml
+    owner: root
+    group: root
+    mode: 0644
+    backup: yes
   notify: restart apm-server
 
+- name: Ensure the APM service is enabled and started
+  service:
+    name: apm-server
+    state: started
+    enabled: yes

--- a/templates/apm-server.yml.j2
+++ b/templates/apm-server.yml.j2
@@ -1,4 +1,5 @@
-################### APM Server Configuration #########################
+# {{ ansible_managed }}
+# Elastic APM Server Configuration
 
 ############################# APM Server ######################################
 


### PR DESCRIPTION
Hi @gnavalesi, and thanks for writing this Ansible role!

This PR brings several minor improvements:
- leverage Ansible \apt` modules to handle package repositories
- directly pass a package list to `apt.name`
- explicitly declare file ownership and permissions
- rotate and backup templated files
- fix YAML and Markdown compliance (indentation, trailing spaces, etc.)
- fix typos